### PR TITLE
Added query for all data sources

### DIFF
--- a/API/Queries/RootQuery.cs
+++ b/API/Queries/RootQuery.cs
@@ -33,7 +33,7 @@ namespace Backend.API.Queries
                         context.GetArgument<float>("lat"),
                         context.GetArgument<float>("lon")));
 
-            Field<StoredMetadataType>("metadata", "metadata for the different data sources",
+            Field<StoredMetadataType>("metadata", "metadata for a data source",
                 new QueryArguments
                 {
                     new QueryArgument<StringGraphType>
@@ -44,6 +44,10 @@ namespace Backend.API.Queries
                 },
                 context => metadataService?.GetMetadata(
                     context.GetArgument<string>("name")));
+
+            Field<ListGraphType<StoredMetadataType>>("allMetadata",
+                "All metadata for every data source, Development mode will return 10 documents", null,
+                _ => metadataService?.GetAllMetadata());
         }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Backend.Mocks.Metadata;
 using Backend.Models.Base.Metadata;
@@ -10,7 +11,7 @@ namespace Backend.API.Services
     public interface IMetadataService
     {
         public Task<StoredMetadata> GetMetadata(string name);
-        public Task<List<StoredMetadata>> GetAllMetadata();
+        public Task<Collection<StoredMetadata>> GetAllMetadata();
     }
 
     public class MetadataService : IMetadataService
@@ -30,9 +31,15 @@ namespace Backend.API.Services
             return await Task.FromResult(_storedMetadata.Find(data => data.Name == name).FirstOrDefault());
         }
 
-        public async Task<List<StoredMetadata>> GetAllMetadata()
+        public async Task<Collection<StoredMetadata>> GetAllMetadata()
         {
-            return await Task.FromResult(_storedMetadata.Find(metadata => true).ToList());
+            var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList());
+            var collectionResult = new Collection<StoredMetadata>();
+            for (var i = 0; i < result.Count; i++)
+            {
+                collectionResult.Add(result[i]);
+            }
+            return collectionResult;
         }
     }
 
@@ -43,7 +50,7 @@ namespace Backend.API.Services
             return await Task.FromResult(MockMetadata.GenerateStoredMetadata());
         }
 
-        public async Task<List<StoredMetadata>> GetAllMetadata()
+        public async Task<Collection<StoredMetadata>> GetAllMetadata()
         {
             return await Task.FromResult(MockMetadata.GenerateMultipleStoredMetadata());
         }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Backend.Mocks.Metadata;
 using Backend.Models.Base.Metadata;
@@ -9,6 +10,7 @@ namespace Backend.API.Services
     public interface IMetadataService
     {
         public Task<StoredMetadata> GetMetadata(string name);
+        public Task<List<StoredMetadata>> GetAllMetadata();
     }
 
     public class MetadataService : IMetadataService
@@ -27,6 +29,11 @@ namespace Backend.API.Services
         {
             return await Task.FromResult(_storedMetadata.Find(data => data.Name == name).FirstOrDefault());
         }
+
+        public async Task<List<StoredMetadata>> GetAllMetadata()
+        {
+            return await Task.FromResult(_storedMetadata.Find(metadata => true).ToList());
+        }
     }
 
     public class MetadataServiceMocked : IMetadataService
@@ -34,6 +41,11 @@ namespace Backend.API.Services
         public async Task<StoredMetadata> GetMetadata(string name)
         {
             return await Task.FromResult(MockMetadata.GenerateStoredMetadata());
+        }
+
+        public async Task<List<StoredMetadata>> GetAllMetadata()
+        {
+            return await Task.FromResult(MockMetadata.GenerateMultipleStoredMetadata());
         }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Backend.Mocks.Metadata;
@@ -33,11 +32,11 @@ namespace Backend.API.Services
 
         public async Task<Collection<StoredMetadata>> GetAllMetadata()
         {
-            var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList());
+            var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList()).ConfigureAwait(false);
             var collectionResult = new Collection<StoredMetadata>();
-            for (var i = 0; i < result.Count; i++)
+            foreach (var t in result)
             {
-                collectionResult.Add(result[i]);
+                collectionResult.Add(t);
             }
             return collectionResult;
         }
@@ -52,7 +51,7 @@ namespace Backend.API.Services
 
         public async Task<Collection<StoredMetadata>> GetAllMetadata()
         {
-            return await Task.FromResult(MockMetadata.GenerateMultipleStoredMetadata());
+            return await Task.FromResult(MockMetadata.GenerateMultipleStoredMetadata()).ConfigureAwait(false);
         }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -34,7 +34,7 @@ namespace Backend.API.Services
         {
             var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList()).ConfigureAwait(false);
             var collectionResult = new Collection<StoredMetadata>();
-            foreach (var t in result) collectionResult.Add(t);
+            foreach (var t in result) {collectionResult.Add(t);}
             return collectionResult;
         }
     }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -33,9 +33,7 @@ namespace Backend.API.Services
         public async Task<Collection<StoredMetadata>> GetAllMetadata()
         {
             var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList()).ConfigureAwait(false);
-            var collectionResult = new Collection<StoredMetadata>();
-            foreach (var t in result) {collectionResult.Add(t);}
-            return collectionResult;
+            return new Collection<StoredMetadata>(result);
         }
     }
 

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -34,10 +34,7 @@ namespace Backend.API.Services
         {
             var result = await Task.FromResult(_storedMetadata.Find(metadata => true).ToList()).ConfigureAwait(false);
             var collectionResult = new Collection<StoredMetadata>();
-            foreach (var t in result)
-            {
-                collectionResult.Add(t);
-            }
+            foreach (var t in result) collectionResult.Add(t);
             return collectionResult;
         }
     }

--- a/BackendTests/UnitTests/MetadataTest.cs
+++ b/BackendTests/UnitTests/MetadataTest.cs
@@ -1,7 +1,43 @@
+using System.Collections.ObjectModel;
+using Backend.Mocks.Metadata;
+using Backend.Models.Base.Metadata.POCO;
+using Xunit;
+
 namespace BackendTests.UnitTests
 {
     public class MetadataTest
     {
-        
+        private readonly StoredMetadata _storedMetadata;
+        private readonly Collection<StoredMetadata> _storedMetadatas;
+
+        public MetadataTest()
+        {
+            _storedMetadata = MockMetadata.GenerateStoredMetadata();
+            _storedMetadatas = MockMetadata.GenerateMultipleStoredMetadata();
+        }
+
+        [Fact]
+        public void MetadataShouldReturnData()
+        {
+            Assert.NotNull(_storedMetadata);
+        }
+
+        [Fact]
+        public void MetadatasShouldReturnData()
+        {
+            Assert.NotNull(_storedMetadatas);
+        }
+
+        [Fact]
+        public void MetaDataHasUrl()
+        {
+            Assert.Contains("http", _storedMetadata.Source);
+        }
+
+        [Fact]
+        public void MetadatasHasGivenLength()
+        {
+            Assert.Equal(10, _storedMetadatas.Count);
+        }
     }
 }

--- a/BackendTests/UnitTests/MetadataTest.cs
+++ b/BackendTests/UnitTests/MetadataTest.cs
@@ -1,0 +1,7 @@
+namespace BackendTests.UnitTests
+{
+    public class MetadataTest
+    {
+        
+    }
+}

--- a/Mocks/Metadata/MockMetadata.cs
+++ b/Mocks/Metadata/MockMetadata.cs
@@ -7,7 +7,7 @@ namespace Backend.Mocks.Metadata
 {
     public static class MockMetadata
     {
-        public static StoredMetadata GenerateStoredMetadata()
+        public static Faker<StoredMetadata> GenerateStoredMetadata()
         {
             var axis = new Faker<Axis>()
                 .RuleFor(o => o.Limit, f => new Collection<int> {f.Random.Int(0, 10), f.Random.Int(20, 50)})
@@ -45,9 +45,7 @@ namespace Backend.Mocks.Metadata
 
         public static Collection<StoredMetadata> GenerateMultipleStoredMetadata()
         {
-            var metadataList = new Collection<StoredMetadata>();
-            for (var i = 0; i < 10; i++) {metadataList.Add(GenerateStoredMetadata());}
-            return metadataList;
+            return new(GenerateStoredMetadata().Generate(10));
         }
     }
 }

--- a/Mocks/Metadata/MockMetadata.cs
+++ b/Mocks/Metadata/MockMetadata.cs
@@ -46,7 +46,7 @@ namespace Backend.Mocks.Metadata
         public static Collection<StoredMetadata> GenerateMultipleStoredMetadata()
         {
             var metadataList = new Collection<StoredMetadata>();
-            for (var i = 0; i < 10; i++) metadataList.Add(GenerateStoredMetadata());
+            for (var i = 0; i < 10; i++) {metadataList.Add(GenerateStoredMetadata());}
             return metadataList;
         }
     }

--- a/Mocks/Metadata/MockMetadata.cs
+++ b/Mocks/Metadata/MockMetadata.cs
@@ -42,5 +42,12 @@ namespace Backend.Mocks.Metadata
 
             return storedMetadata;
         }
+
+        public static List<StoredMetadata> GenerateMultipleStoredMetadata()
+        {
+            var metadataList = new List<StoredMetadata>();
+            for (var i = 0; i < 10; i++) metadataList.Add(GenerateStoredMetadata());
+            return metadataList;
+        }
     }
 }

--- a/Mocks/Metadata/MockMetadata.cs
+++ b/Mocks/Metadata/MockMetadata.cs
@@ -43,9 +43,9 @@ namespace Backend.Mocks.Metadata
             return storedMetadata;
         }
 
-        public static List<StoredMetadata> GenerateMultipleStoredMetadata()
+        public static Collection<StoredMetadata> GenerateMultipleStoredMetadata()
         {
-            var metadataList = new List<StoredMetadata>();
+            var metadataList = new Collection<StoredMetadata>();
             for (var i = 0; i < 10; i++) metadataList.Add(GenerateStoredMetadata());
             return metadataList;
         }


### PR DESCRIPTION
Query 'allMetadata' returns all the metadata documents.
Has support for mocking and actual data. Lacks tests.

Closes #69 